### PR TITLE
Nothing to do on an OPTIONS request, could interfere with other packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ matrix:
       env: SYMFONY_VERSION=4.4.*@dev
     - php: 7.3
       env: SYMFONY_VERSION=5.0.*@dev
+    - php: 7.4
+      env: SYMFONY_VERSION=4.4.*@dev
+    - php: 7.4
+      env: SYMFONY_VERSION=5.0.*@dev
 
 sudo: false
 

--- a/src/EventSubscriber/RestApiEventSubscriber.php
+++ b/src/EventSubscriber/RestApiEventSubscriber.php
@@ -140,6 +140,8 @@ class RestApiEventSubscriber implements EventSubscriberInterface
      */
     protected function eventRequestMatches(KernelEvent $event)
     {
+        if ($event->getRequest()->getMethod() === 'OPTIONS') return false;
+
         return $this->requestMatcher->matches($event->getRequest(), $event->getRequestType());
     }
 }

--- a/src/EventSubscriber/RestApiEventSubscriber.php
+++ b/src/EventSubscriber/RestApiEventSubscriber.php
@@ -6,11 +6,8 @@ use MediaMonks\RestApi\Request\RequestMatcherInterface;
 use MediaMonks\RestApi\Request\RequestTransformerInterface;
 use MediaMonks\RestApi\Response\ResponseTransformerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
-use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
-use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\Event\KernelEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
@@ -140,7 +137,7 @@ class RestApiEventSubscriber implements EventSubscriberInterface
      */
     protected function eventRequestMatches(KernelEvent $event)
     {
-        if ($event->getRequest()->getMethod() === 'OPTIONS') return false;
+        if ($event->getRequest()->getMethod() === Request::METHOD_OPTIONS) return false;
 
         return $this->requestMatcher->matches($event->getRequest(), $event->getRequestType());
     }

--- a/src/Model/AbstractResponseModel.php
+++ b/src/Model/AbstractResponseModel.php
@@ -123,7 +123,12 @@ abstract class AbstractResponseModel
     {
         $traces = [];
         foreach ($this->throwable->getTrace() as $trace) {
-            $trace['args'] = json_decode(json_encode($trace['args']), true);
+            // Since PHP 7.4 the args key got disabled, to enable it again:
+            // zend.exception_ignore_args = On
+            if (array_key_exists('args', $trace)) {
+                $trace['args'] = json_decode(json_encode($trace['args']), true);
+            }
+
             $traces[] = $trace;
         }
 
@@ -262,6 +267,7 @@ abstract class AbstractResponseModel
     }
 
     // @codeCoverageIgnoreStart
+
     /**
      * This is called when an exception is thrown during the response transformation
      *

--- a/tests/src/EventSubscriber/RestApiEventSubscriberTest.php
+++ b/tests/src/EventSubscriber/RestApiEventSubscriberTest.php
@@ -69,10 +69,11 @@ class RestApiEventSubscriberTest extends \PHPUnit_Framework_TestCase
             [$matcher, $requestTransformer, $responseTransformer]
         );
 
+        $request = m::mock(Request::class);
+        $request->shouldReceive('getMethod')->andReturn(Request::METHOD_GET);
+
         $mockEvent = m::mock(RequestEvent::class);
-        $mockEvent->shouldReceive('getRequest')->andReturn(
-            m::mock(Request::class)
-        );
+        $mockEvent->shouldReceive('getRequest')->andReturn($request);
         $mockEvent->shouldReceive('getRequestType');
 
         $subject->onRequest($mockEvent);
@@ -98,6 +99,7 @@ class RestApiEventSubscriberTest extends \PHPUnit_Framework_TestCase
 
         $kernel = m::mock(HttpKernel::class);
         $request = m::mock(Request::class);
+        $request->shouldReceive('getMethod')->andReturn(Request::METHOD_GET);
 
         $event = new RequestEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
 
@@ -105,6 +107,36 @@ class RestApiEventSubscriberTest extends \PHPUnit_Framework_TestCase
 
         try {
             $requestTransformer->shouldHaveReceived('transform')->between(1, 1);
+            $this->assertTrue(true);
+        } catch (\Exception $e) {
+            $this->assertTrue(false, $e->getMessage());
+        }
+    }
+
+    public function testOnRequestOptionMethod()
+    {
+        [$matcher, $requestTransformer, $responseTransformer] = $this->getMocks();
+        $matcher->shouldReceive('matches')->andReturn(true);
+        $requestTransformer->shouldReceive('transform');
+
+        $subject = $this->getSubject(
+            [$matcher, $requestTransformer, $responseTransformer]
+        );
+
+        $kernel = m::mock(HttpKernel::class);
+        $request = m::mock(Request::class);
+
+        $request->shouldReceive('setMethod')->andReturn(Request::METHOD_OPTIONS);
+        $request->shouldReceive('getMethod')->andReturn(Request::METHOD_OPTIONS);
+
+        $request->setMethod(Request::METHOD_OPTIONS);
+
+        $event = new RequestEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+
+        $subject->onRequest($event);
+
+        try {
+            $requestTransformer->shouldNotHaveReceived('transform');
             $this->assertTrue(true);
         } catch (\Exception $e) {
             $this->assertTrue(false, $e->getMessage());
@@ -128,6 +160,8 @@ class RestApiEventSubscriberTest extends \PHPUnit_Framework_TestCase
 
         $kernel = m::mock(HttpKernel::class);
         $request = m::mock(Request::class);
+        $request->shouldReceive('getMethod')->andReturn(Request::METHOD_GET);
+
         $e = new \Exception();
 
         $event = new ExceptionEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST, $e);
@@ -153,6 +187,8 @@ class RestApiEventSubscriberTest extends \PHPUnit_Framework_TestCase
 
         $kernel = m::mock(HttpKernel::class);
         $request = m::mock(Request::class);
+        $request->shouldReceive('getMethod')->andReturn(Request::METHOD_GET);
+
         $e = new \Exception();
 
         $event = new ExceptionEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST, $e);
@@ -183,6 +219,7 @@ class RestApiEventSubscriberTest extends \PHPUnit_Framework_TestCase
 
         $kernel = m::mock(HttpKernel::class);
         $request = m::mock(Request::class);
+        $request->shouldReceive('getMethod')->andReturn(Request::METHOD_GET);
 
         $event = new ViewEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST, 'foo');
 
@@ -208,6 +245,7 @@ class RestApiEventSubscriberTest extends \PHPUnit_Framework_TestCase
 
         $kernel = m::mock(HttpKernel::class);
         $request = m::mock(Request::class);
+        $request->shouldReceive('getMethod')->andReturn(Request::METHOD_GET);
 
         $event = new ViewEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST, 'foo');
 
@@ -238,6 +276,7 @@ class RestApiEventSubscriberTest extends \PHPUnit_Framework_TestCase
 
         $kernel = m::mock(HttpKernel::class);
         $request = m::mock(Request::class);
+        $request->shouldReceive('getMethod')->andReturn(Request::METHOD_GET);
         $response = m::mock(Response::class);
 
         $event = new ResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response);
@@ -266,6 +305,7 @@ class RestApiEventSubscriberTest extends \PHPUnit_Framework_TestCase
 
         $kernel = m::mock(HttpKernel::class);
         $request = m::mock(Request::class);
+        $request->shouldReceive('getMethod')->andReturn(Request::METHOD_GET);
 
         $event = new ResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response);
 
@@ -295,6 +335,7 @@ class RestApiEventSubscriberTest extends \PHPUnit_Framework_TestCase
 
         $kernel = m::mock(HttpKernel::class);
         $request = m::mock(Request::class);
+        $request->shouldReceive('getMethod')->andReturn(Request::METHOD_GET);
         $response = m::mock(Response::class);
 
         $event = new ResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response);
@@ -321,6 +362,7 @@ class RestApiEventSubscriberTest extends \PHPUnit_Framework_TestCase
 
         $kernel = m::mock(HttpKernel::class);
         $request = m::mock(Request::class);
+        $request->shouldReceive('getMethod')->andReturn(Request::METHOD_GET);
         $response = m::mock(Response::class);
 
         $event = new ResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response);


### PR DESCRIPTION
In combination with nelmio cors bundle, the cors response headers seem to be removed.