### PR TITLE
fix whitespace character

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     }
   ],
   "require": {
-    "php": "^7.1 || ^8.0",
+    "php": "^7.1 || ^8.0",
     "symfony/http-kernel": "^4.4|^5.0",
     "ext-json": "*"
   },


### PR DESCRIPTION
somehow an invalid nbsp character (`<0xa0>`) found its way into composer.json instead of a legal whitespace...