### PR TITLE
Add support for application/merge-patch+json MIME type

### DIFF
--- a/src/Request/RequestTransformer.php
+++ b/src/Request/RequestTransformer.php
@@ -19,7 +19,12 @@ class RequestTransformer implements RequestTransformerInterface
 
     protected function acceptJsonBody(Request $request)
     {
-        if (str_starts_with($request->headers->get('Content-Type', ''), 'application/json')) {
+        $contentType = $request->headers->get('Content-Type', '');
+
+        if (
+            str_starts_with($contentType, 'application/json') ||
+            str_starts_with($contentType, 'application/merge-patch+json')
+        ) {
             $data = json_decode($request->getContent(), true);
             $request->request->replace(is_array($data) ? $data : []);
         }

--- a/tests/Request/RequestTransformerTest.php
+++ b/tests/Request/RequestTransformerTest.php
@@ -22,21 +22,27 @@ class RequestTransformerTest extends TestCase
         return new RequestTransformer($serializer);
     }
 
-    public function testTransformChangesRequestParameters()
+    /**
+     * @dataProvider provideJsonMimeTypes
+     */
+    public function testTransformChangesRequestParameters(string $contentType): void
     {
         $subject = $this->getSubject();
         $content = ['Hello', 'World!'];
-        $request = $this->getRequest($content);
+        $request = $this->getRequest(content: $content, contentType: $contentType);
 
         $subject->transform($request);
 
         $this->assertEquals($content, iterator_to_array($request->request->getIterator()));
     }
 
-    public function testTransformChangesRequestFormatDefault()
+    /**
+     * @dataProvider provideJsonMimeTypes
+     */
+    public function testTransformChangesRequestFormatDefault(string $contentType)
     {
         $subject = $this->getSubject();
-        $request = $this->getRequest([]);
+        $request = $this->getRequest(content: [], contentType: $contentType);
 
         $subject->transform($request);
 
@@ -65,11 +71,19 @@ class RequestTransformerTest extends TestCase
         $this->assertEquals(Format::getDefault(), $request->getRequestFormat());
     }
 
-    protected function getRequest($content)
+    protected function getRequest(mixed $content, string $contentType = 'application/json'): Request
     {
         $request = Request::create('/');
         $request->initialize([], [], [], [], [], [], json_encode($content));
-        $request->headers->add(['Content-type' => 'application/json']);
+        $request->headers->add(['Content-type' => $contentType]);
         return $request;
+    }
+
+    public static function provideJsonMimeTypes(): array
+    {
+        return [
+            'application/json'             => ['application/json'],
+            'application/merge-patch+json' => ['application/merge-patch+json'],
+        ];
     }
 }


### PR DESCRIPTION
This aims to fix the issue of [JSON Merge Patch](https://www.rfc-editor.org/rfc/rfc7396) requests not having their request bodies decoded into an associative array.

With this change, both content types:
-  `application/json`
- `application/merge-patch+json`

will be handled the same way (JSON body decoded).